### PR TITLE
feat: container health-check

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,5 +14,8 @@ COPY --from=builder /app .
 # Expose port
 EXPOSE 3000
 
+# Health check
+HEALTHCHECK --interval=30s --timeout=5s --start-period=5s CMD wget -qO- http://localhost:3000/health || exit 1
+
 # Start the application
 CMD ["npm", "start"] 

--- a/server.js
+++ b/server.js
@@ -414,6 +414,14 @@ app.get('/managers/toast', (req, res) => {
     res.sendFile(path.join(PUBLIC_DIR, 'managers', 'toast.js'));
 });
 
+app.get('/health', (_req, res) => {
+  res.json({
+    status: 'ok',
+    timestamp: new Date().toISOString(),
+    uptime: process.uptime()
+  });
+});
+
 app.get('*', (req, res) => {
     res.sendFile(path.join(__dirname, 'public', 'index.html'));
 });


### PR DESCRIPTION
### What
- add `/health` route
- add `HEALTHCHECK` to Dockerfile

### Why
- Allows Docker/K8s (or `docker compose`) to restart the container automatically if the app becomes unresponsive.

### Test
```
npm start          
curl http://localhost:3000/health   # → ok
```
