### PR TITLE
Switch ASN lookup to RIPEstat and PeeringDB

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,8 +49,10 @@ The application uses the following free services:
      - Free with no rate limits
      - No API key required
 
-- **ASN Lookup**: [BGPView API](https://bgpview.docs.apiary.io/)
-  - Provides ASN details and related information
+- **ASN Lookup**: [RIPEstat API](https://stat.ripe.net/docs/data-api/ripestat-data-api) + [PeeringDB](https://www.peeringdb.com/apidocs/)
+  - RIPEstat provides ASN details and WHOIS information
+  - PeeringDB provides traffic ratio and website info
+  - Works for all RIRs (ARIN, RIPE, APNIC, LACNIC, AFRINIC)
   - Free to use
   - No authentication required
 
@@ -154,7 +156,8 @@ Please note that some APIs used have rate limits:
 - ipapi.co: 1000 requests per day (free tier)
 - ip-api.com: 45 requests per minute
 - ipwho.is: No rate limits
-- BGPView: unknown rate limit waiting for reply.
+- RIPEstat: No strict rate limits (fair use policy)
+- PeeringDB: No strict rate limits (fair use policy)
 
 The application automatically handles rate limits by falling back to alternative services when needed.
 

--- a/public/index.js
+++ b/public/index.js
@@ -419,7 +419,7 @@ document.addEventListener('DOMContentLoaded', () => {
             } else {
                 queryTypeDiv.textContent = `Type: ${data.type.toUpperCase()}${
                     data.type === 'ip' ? ` (Source: ${data.data.source})` :
-                    data.type === 'asn' ? ' (Source: BGPView)' :
+                    data.type === 'asn' ? ' (Source: RIPEstat + PeeringDB)' :
                     data.type === 'whois' ? ' (Source: Direct WHOIS Server)' : ''
                 }`;
                 

--- a/server.js
+++ b/server.js
@@ -266,6 +266,153 @@ const ipLookupServices = [
     }
 ];
 
+// Helper function to fetch ASN data from RIPEstat and PeeringDB
+async function fetchASNData(asnNumber) {
+    // RIPEstat whois endpoint provides comprehensive ASN information
+    // Works for all RIRs: ARIN, RIPE, APNIC, LACNIC, AFRINIC
+    const whoisUrl = `https://stat.ripe.net/data/whois/data.json?resource=AS${asnNumber}`;
+    const overviewUrl = `https://stat.ripe.net/data/as-overview/data.json?resource=AS${asnNumber}`;
+    const peeringDbUrl = `https://www.peeringdb.com/api/net?asn=${asnNumber}`;
+
+    // Fetch all endpoints in parallel (PeeringDB is optional, don't fail if unavailable)
+    const [whoisResponse, overviewResponse, peeringDbResponse] = await Promise.all([
+        axios.get(whoisUrl),
+        axios.get(overviewUrl),
+        axios.get(peeringDbUrl).catch(() => ({ data: { data: [] } }))
+    ]);
+
+    const whoisData = whoisResponse.data;
+    const overviewData = overviewResponse.data;
+    const peeringDbData = peeringDbResponse.data?.data?.[0] || {};
+
+    // Parse WHOIS records to extract relevant fields
+    const records = whoisData.data?.records || [];
+    const flatRecords = records.flat();
+
+    // Helper to find value by key in WHOIS records (case-insensitive)
+    const findValue = (key) => {
+        const record = flatRecords.find(r => r.key?.toLowerCase() === key.toLowerCase());
+        return record?.value || '';
+    };
+
+    // Helper to find all values by key (case-insensitive)
+    const findAllValues = (key) => {
+        return flatRecords
+            .filter(r => r.key?.toLowerCase() === key.toLowerCase())
+            .map(r => r.value)
+            .filter(Boolean);
+    };
+
+    // Determine RIR from source field or authority
+    const source = findValue('source') || whoisData.data?.authorities?.[0] || '';
+    const isARIN = source.toUpperCase() === 'ARIN';
+
+    // Extract holder info from overview (format: "NAME - Description, CC")
+    const holder = overviewData.data?.holder || '';
+    const holderParts = holder.split(' - ');
+    const name = holderParts[0] || findValue('as-name') || findValue('ASName') || findValue('aut-num');
+
+    // Try to extract country code from holder or WHOIS
+    let countryCode = findValue('country');
+    if (!countryCode && holder) {
+        // Try to extract from holder string (e.g., "CLOUDFLARENET - Cloudflare, Inc., US")
+        const ccMatch = holder.match(/,\s*([A-Z]{2})$/);
+        if (ccMatch) countryCode = ccMatch[1];
+    }
+
+    // Extract description - ARIN uses OrgName, RIPE uses descr
+    const descriptions = findAllValues('descr');
+    const orgName = findValue('OrgName');
+    const description = descriptions[0] || orgName || (holderParts.length > 1 ? holderParts.slice(1).join(' - ') : '');
+
+    // Extract email contacts - handle both RIPE and ARIN formats
+    let emailContacts = findAllValues('e-mail');
+    if (emailContacts.length === 0) {
+        // ARIN format: OrgTechEmail, OrgNOCEmail
+        const techEmail = findAllValues('OrgTechEmail');
+        const nocEmail = findAllValues('OrgNOCEmail');
+        emailContacts = [...new Set([...techEmail, ...nocEmail])];
+    }
+    // Fallback to contact handles if no emails found
+    if (emailContacts.length === 0) {
+        const techC = findAllValues('tech-c');
+        const adminC = findAllValues('admin-c');
+        emailContacts = [...techC, ...adminC];
+    }
+
+    // Extract abuse contacts - handle both RIPE and ARIN formats
+    let abuseContacts = findAllValues('abuse-mailbox');
+    if (abuseContacts.length === 0) {
+        // ARIN format: OrgAbuseEmail
+        abuseContacts = findAllValues('OrgAbuseEmail');
+    }
+    if (abuseContacts.length === 0) {
+        abuseContacts = findAllValues('abuse-c');
+    }
+
+    // Extract address - handle both RIPE and ARIN formats
+    const remarks = findAllValues('remarks');
+    let ownerAddress = findAllValues('address');
+
+    if (ownerAddress.length === 0 && isARIN) {
+        // ARIN uses separate fields: Address, City, StateProv, PostalCode, Country
+        const streetAddr = findValue('Address');
+        const city = findValue('City');
+        const state = findValue('StateProv');
+        const postal = findValue('PostalCode');
+        const addrCountry = findValue('Country');
+
+        const addrParts = [streetAddr];
+        if (city || state || postal) {
+            addrParts.push([city, state, postal].filter(Boolean).join(', '));
+        }
+        if (addrCountry) addrParts.push(addrCountry);
+        ownerAddress = addrParts.filter(Boolean);
+    }
+
+    if (ownerAddress.length === 0) {
+        ownerAddress = remarks.filter(r => !r.includes('http'));
+    }
+
+    const rirMap = {
+        'RIPE': 'RIPE NCC',
+        'ARIN': 'ARIN',
+        'APNIC': 'APNIC',
+        'LACNIC': 'LACNIC',
+        'AFRINIC': 'AFRINIC',
+        'RADB': 'RADB'
+    };
+    const rirName = rirMap[source.toUpperCase()] || source || 'Unknown';
+
+    // Extract dates - handle both RIPE and ARIN formats
+    // ARIN uses RegDate, RIPE uses created
+    const created = findValue('created') || findValue('RegDate') || findValue('reg-date');
+    const lastModified = findValue('last-modified') || findValue('Updated') || findValue('changed');
+
+    // Extract website - prefer PeeringDB, fallback to WHOIS remarks
+    const website = peeringDbData.website || remarks.find(r => r.includes('http')) || '';
+
+    // Build response in BGPView-compatible format
+    return {
+        data: {
+            asn: parseInt(asnNumber),
+            name: name,
+            description_short: description,
+            country_code: countryCode,
+            website: website,
+            email_contacts: emailContacts,
+            abuse_contacts: abuseContacts.length > 0 ? abuseContacts : emailContacts,
+            owner_address: ownerAddress,
+            rir_allocation: {
+                rir_name: rirName,
+                date_allocated: created
+            },
+            traffic_ratio: peeringDbData.info_ratio || null,  // From PeeringDB
+            date_updated: lastModified
+        }
+    };
+}
+
 // Helper function to try IP lookup services in sequence
 async function tryIpLookup(ip) {
     // Remove brackets and CIDR notation for the lookup
@@ -361,7 +508,8 @@ app.get('/api/lookup/:query', async (req, res) => {
             case 'asn':
                 // Remove 'AS' prefix if present
                 const asnNumber = query.replace(/^(AS|as)/i, '');
-                response = await axios.get(`https://api.bgpview.io/asn/${asnNumber}`);
+                const asnData = await fetchASNData(asnNumber);
+                response = { data: asnData };
                 break;
             default:
                 return res.status(400).json({ 


### PR DESCRIPTION
Replaced BGPView ASN lookup with RIPEstat and PeeringDB APIs for broader RIR support and richer ASN details. Updated documentation and UI to reflect new data sources. Added helper to parse and normalize ASN data from RIPEstat and PeeringDB, improving coverage and accuracy.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * ASN lookup sources updated from BGPView to RIPEstat + PeeringDB, providing expanded Regional Internet Registry coverage with no authentication requirements and fair-use rate limits. Automatic fallback behavior maintained.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR migrates the ASN (Autonomous System Number) lookup functionality from the BGPView API to a combination of RIPEstat and PeeringDB APIs. The change provides broader coverage across all Regional Internet Registries (ARIN, RIPE, APNIC, LACNIC, AFRINIC) and enriches the ASN data with additional details like traffic ratios and website information. The implementation includes a new helper function `fetchASNData()` that normalizes data from both RIPEstat's WHOIS and overview endpoints as well as PeeringDB, parsing various WHOIS record formats to maintain compatibility with the existing BGPView-style response structure. Documentation and UI labels have been updated to reflect the new data sources.

⏱️ Estimated Review Time: 15-30 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `README.md` |
| 2 | `public/index.js` |
| 3 | `server.js` |
</details>



[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)

<!-- RECURSEML_SUMMARY:END -->